### PR TITLE
Enable grunt-watch with mochaTest

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -21,8 +21,8 @@ module.exports = function(grunt) {
       }
     },
     watch: {
-      files: ['Gruntfile.js', 'test/**/*.coffee'],
-      tasks: ['test']
+      files: ['Gruntfile.js', 'test/**/*.coffee','test/**/*.js'],
+      tasks: ['mochaTest']
     }
   });
 };


### PR DESCRIPTION
I try to execute test from grunt watch.

```
$ grunt watch 
```

Is this useful?
