### PR TITLE
Fix assertion for not existing files

### DIFF
--- a/test/test-app.js
+++ b/test/test-app.js
@@ -19,10 +19,16 @@ describe('hubot:app', function () {
 
   it('creates files', function () {
     assert.file([
-      'bower.json',
+      'bin/hubot',
+      'bin/hubot.cmd',
+      'Procfile',
+      'README.md',
+      'external-scripts.json',
+      'hubot-scripts.json',
+      '.gitignore',
       'package.json',
+      'scripts/example.coffee',
       '.editorconfig',
-      '.jshintrc'
     ]);
   });
 });


### PR DESCRIPTION
Test fails with

```
$ mocha
  1) hubot:app creates files:
     AssertionError: bower.json, no such file or directory
      at /Users/yuuki/src/github.com/github/generator-hubot/node_modules/yeoman-generator/lib/test/assert.js:61:14
      at Array.forEach (native)
      at Function.assert.file (/Users/yuuki/src/github.com/github/generator-hubot/node_modules/yeoman-generator/lib/test/assert.js:59:10)
      at Context.<anonymous> (/Users/yuuki/src/github.com/github/generator-hubot/test/test-app.js:21:12)
```

So I fixed this.
