### PR TITLE
Add coffee-script@1.6.3 to devDependencies

### DIFF
--- a/generators/script/templates/_package.json
+++ b/generators/script/templates/_package.json
@@ -24,6 +24,7 @@
   },
 
   "devDependencies": {
+    "coffee-script": "1.6.3",
     "hubot": "2.x",
     "mocha": "*",
     "chai": "*",


### PR DESCRIPTION
`npm test` does not work.

```
$ npm test

> hubot-hello-world@0.0.0 test /home/bouzuya/hubot-hello-world
> grunt test

Running "mochaTest:test" (mochaTest) task
Warning: Cannot find module 'coffee-script' Use --force to continue.

Aborted due to warnings.
npm ERR! Test failed.  See above for more details.
npm ERR! not ok code 0
```
