### PR TITLE
Arguments

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -69,11 +69,11 @@ var HubotGenerator = yeoman.generators.Base.extend({
     yeoman.generators.Base.apply(this, arguments);
 
     // FIXME add documentation to these
-    this.option('owner');
-    this.option('name');
-    this.option('description');
-    this.option('adapter');
-    this.option('defaults');
+    this.option('owner', {desc: "Name and email of the owner of new bot (ie Example <user@example.com>)"});
+    this.option('name', {desc: "Name of new bot"});
+    this.option('description', {desc: "Description of the new bot"});
+    this.option('adapter', {desc: "Hubot adapter to use for new bot"});
+    this.option('defaults', {desc: "Accept defaults and don't prompt for user input"});
 
     if (this.options.defaults) {
       this.options.owner = this.options.owner || this.determineDefaultOwner();


### PR DESCRIPTION
This adds support for configuring the generated bot with arguments instead of prompting for them:

```
yo hubot --adapter=campfire --owner="josh nichols <josh@technicalpickles.com>" --name=testbot --description="such bot"
```

This does still prompt you for what to do about conflicts and stuff if you are running on-top of an existing bot. That can be worked around by passing in `--force`

cc https://github.com/github/generator-hubot/issues/12 https://github.com/github/hubot/issues/605 https://github.com/github/hubot/issues/822
