### PR TITLE
Release 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+0.2.0
+=====
+
+* Start tracking changes in CHANGELOG.md
+* [app] Fix generated gitignore to correctly ignore .hubot_history https://github.com/github/generator-hubot/pull/17
+* [app] Add generator command line options to prevent user prompts, and add --defaults to accept defaults without prompting https://github.com/github/generator-hubot/pull/14


### PR DESCRIPTION
- [app] Fix generated gitignore to correctly ignore .hubot_history https://github.com/github/generator-hubot/pull/17
- [app] Add generator command line options to prevent user prompts, and add --defaults to accept defaults without prompting https://github.com/github/generator-hubot/pull/14
