### PR TITLE
Less boilerplate in script's index.coffee

### DIFF
--- a/generators/script/index.js
+++ b/generators/script/index.js
@@ -125,7 +125,7 @@ var HubotScriptGenerator = yeoman.generators.Base.extend({
       this.copy('Gruntfile.js', 'Gruntfile.js');
       this.copy('gitignore', '.gitignore');
       this.copy('.travis.yml', '.travis.yml');
-      this.copy('index.coffee', 'index.coffee');
+      this.template('index.coffee', 'index.coffee');
       this.template('_package.json', 'package.json');
       this.copy('README.md', 'README.md');
     },

--- a/generators/script/templates/index.coffee
+++ b/generators/script/templates/index.coffee
@@ -1,12 +1,5 @@
-fs = require 'fs'
 path = require 'path'
 
 module.exports = (robot, scripts) ->
   scriptsPath = path.resolve(__dirname, 'src')
-  fs.exists scriptsPath, (exists) ->
-    if exists
-      for script in fs.readdirSync(scriptsPath)
-        if scripts? and '*' not in scripts
-          robot.loadFile(scriptsPath, script) if script in scripts
-        else
-          robot.loadFile(scriptsPath, script)
+  robot.loadFile(scriptsPath, '<%= scriptName %>.coffee')


### PR DESCRIPTION
Simplify index.coffee to just use robot.loadFile on the generated script in src/, as I proposed in  https://github.com/github/generator-hubot/pull/19 

cc @kballard https://github.com/github/hubot/pull/831