### PR TITLE
Fix option parsing to prevent trying to install `hubot-true`

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -69,11 +69,30 @@ var HubotGenerator = yeoman.generators.Base.extend({
     yeoman.generators.Base.apply(this, arguments);
 
     // FIXME add documentation to these
-    this.option('owner', {desc: "Name and email of the owner of new bot (ie Example <user@example.com>)"});
-    this.option('name', {desc: "Name of new bot"});
-    this.option('description', {desc: "Description of the new bot"});
-    this.option('adapter', {desc: "Hubot adapter to use for new bot"});
-    this.option('defaults', {desc: "Accept defaults and don't prompt for user input"});
+    this.option('owner', {
+      desc: "Name and email of the owner of new bot (ie Example <user@example.com>)"
+    });
+
+    this.option('name', {
+      desc: "Name of new bot",
+      type: String
+    });
+
+    this.option('description', {
+      desc: "Description of the new bot",
+      type: String
+    });
+
+    this.option('adapter', {
+      desc: "Hubot adapter to use for new bot",
+      type: String,
+      required: true
+    });
+
+    this.option('defaults', {
+      desc: "Accept defaults and don't prompt for user input",
+      type: Boolean
+    });
 
     if (this.options.defaults) {
       this.options.owner = this.options.owner || this.determineDefaultOwner();

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -70,7 +70,8 @@ var HubotGenerator = yeoman.generators.Base.extend({
 
     // FIXME add documentation to these
     this.option('owner', {
-      desc: "Name and email of the owner of new bot (ie Example <user@example.com>)"
+      desc: "Name and email of the owner of new bot (ie Example <user@example.com>)",
+      type: String
     });
 
     this.option('name', {
@@ -85,8 +86,7 @@ var HubotGenerator = yeoman.generators.Base.extend({
 
     this.option('adapter', {
       desc: "Hubot adapter to use for new bot",
-      type: String,
-      required: true
+      type: String
     });
 
     this.option('defaults', {
@@ -99,6 +99,22 @@ var HubotGenerator = yeoman.generators.Base.extend({
       this.options.name = this.options.name || this.determineDefaultName();
       this.options.adapter = this.options.adapter || this.defaultAdapter;
       this.options.description = this.options.description || this.defaultDescription;
+    }
+
+    if (this.options.owner == true) {
+      this.env.error("Missing owner. Make sure to specify it like --owner=\"<owner>\"");
+    }
+
+    if (this.options.name == true) {
+      this.env.error("Missing name. Make sure to specify it like --name=\"<name>\"");
+    }
+
+    if (this.options.description == true) {
+      this.env.error("Missing description. Make sure to specify it like --description=\"<description>\"");
+    }
+
+    if (this.options.adapter == true) {
+      this.env.error("Missing adapter name. Make sure to specify it like --adapter=<adapter>");
     }
   },
 


### PR DESCRIPTION
This is a possible fix to https://github.com/github/hubot/issues/838 . Currently, if you say `yo hubot --adapter slack`, the adapter ends up being set to `true`.

This PR specifies a type for each option to String or Boolean. It doesn't seem to quite prevent the bad behavior yet, so needs some work:

```
2.1.4-github ~/src/scratchbot 
$ yo hubot --adapter
                     _____________________________
                    /                             \
   //\              |      Extracting input for    |
  ////\    _____    |   self-replication process   |
 //////\  /_____\   \                             /
 ======= |[^_/\_]|   /----------------------------
  |   | _|___@@__|__
  +===+/  ///     \_\
   | |_\ /// HUBOT/\\
   |___/\//      /  \\
         \      /   +---+
          \____/    |   |
           | //|    +===+
            \//      |xx|

? Owner: Josh Nichols <technicalpickles@github.com>
? Bot name: scratchbot
? Description: A simple helpful robot for your Company
identical bin/hubot
identical bin/hubot.cmd
identical Procfile
identical README.md
identical external-scripts.json
identical hubot-scripts.json
identical .editorconfig
                     _____________________________
 _____              /                             \
 \    \             |   Self-replication process   |
 |    |    _____    |          complete...         |
 |__\\|   /_____\   \     Good luck with that.    /
   |//+  |[^_/\_]|   /----------------------------
  |   | _|___@@__|__
  +===+/  ///     \_\
   | |_\ /// HUBOT/\\
   |___/\//      /  \\
         \      /   +---+
          \____/    |   |
           | //|    +===+
            \//      |xx|

npm ERR! Darwin 14.0.0
npm ERR! argv "node" "/opt/boxen/nodenv/versions/v0.10/bin/npm" "install" "hubot" "hubot-scripts" "hubot-diagnostics" "hubot-help" "hubot-heroku-keepalive" "hubot-google-images" "hubot-google-translate" "hubot-pugme" "hubot-maps" "hubot-redis-brain" "hubot-rules" "hubot-shipit" "hubot-youtube" "hubot-true" "--save"
npm ERR! node v0.10.21
npm ERR! npm  v2.1.11
npm ERR! code E404

npm ERR! 404 Not Found: hubot-true
npm ERR! 404
npm ERR! 404 'hubot-true' is not in the npm registry.
npm ERR! 404 You should bug the author to publish it (or use the name yourself!)
npm ERR! 404 It was specified as a dependency of 'scratchbot'
npm ERR! 404
npm ERR! 404 Note that you can also install from a
npm ERR! 404 tarball, folder, http url, or git url.
```