### PR TITLE
Let sinon-chai deal with sinon and chai

### DIFF
--- a/generators/script/templates/_package.json
+++ b/generators/script/templates/_package.json
@@ -26,9 +26,7 @@
   "devDependencies": {
     "hubot": "2.x",
     "mocha": "*",
-    "chai": "*",
     "sinon-chai": "*",
-    "sinon": "*",
     "grunt-mocha-test": "~0.7.0",
     "grunt-release": "~0.6.0",
     "matchdep": "~0.1.2",


### PR DESCRIPTION
Latest version of `sinon-chai` has `peerDependencies` for `sinon` and `chai`, that the explicit unbounded dependency here conflicts with. Specifically `sinon-chai` wants a version of `chai` < 2 however the latest version is > 2 and ends up conflicting.

The error encountered was during the final step of `yo hubot:script` (the npm install part):

```
npm ERR! Linux 3.2.0-75-generic
npm ERR! argv "/usr/local/bin/node" "/usr/local/bin/npm" "install"
npm ERR! node v0.12.0
npm ERR! npm  v2.5.1
npm ERR! code EPEERINVALID

npm ERR! peerinvalid The package chai does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer sinon-chai@2.6.0 wants chai@>=1.9.2 <2
```