### PR TITLE
Move coffee-script dependency into hubot-app

### DIFF
--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -8,6 +8,7 @@
   "description": "<%= botDescription %>",
 
   "dependencies": {
+    "coffee-script": "<%= botCoffee %>"
   },
 
   "engines": {

--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
     "hubot-script"
   ],
   "dependencies": {
-    "yeoman-generator": "^0.17.0",
     "chalk": "^0.5.0",
-    "yosay": "^0.3.0",
-    "npm-name": "^1.0.1"
+    "npm": "^2.5.1",
+    "yeoman-generator": "^0.17.0",
+    "yosay": "^0.3.0"
   },
   "devDependencies": {
     "coffee-script": "^1.6.3",


### PR DESCRIPTION
In the interest of speeding along the abilty to use `coffee-script > 1.6.3` this is an attempt at the approach suggested in github/hubot#863.

For now it defaults to coffee version `1.6.3`.

It's probably possible to get away with a more lax version lock on `npm` so that the vast majority of users can get away with the promotion of their global `npm` to support the new checking functionality.