### PR TITLE
Add coffee-script as a development dependency

### DIFF
--- a/generators/script/templates/_package.json
+++ b/generators/script/templates/_package.json
@@ -27,6 +27,7 @@
     "hubot": "2.x",
     "mocha": "*",
     "chai": "*",
+    "coffee-script": "^1.6.3",
     "sinon-chai": "*",
     "sinon": "*",
     "grunt-mocha-test": "~0.7.0",


### PR DESCRIPTION
While reviewing https://github.com/github/generator-hubot/pull/6, I realized that `grunt test` doesn't work because coffeescript is missing :sweat: 

This adds the same version of coffee-script that hubot upstream is currently using.