### PR TITLE
Only call git helper functions if they are functions

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -47,8 +47,20 @@ var hubotEndSay = function() {
 var HubotGenerator = yeoman.generators.Base.extend({
 
   determineDefaultOwner: function() {
-    var userName = this.user.git.name();
-    var userEmail = this.user.git.email();
+    var userName;
+    var userEmail;
+
+    if (typeof(this.user.git.name) == 'function') {
+      userName = this.user.git.name()
+    } else {
+      userName = this.user.git.name
+    }
+
+    if (typeof(this.user.git.email) == 'function') {
+      userEmail = this.user.git.email()
+    } else {
+      userEmail = this.user.git.email
+    }
 
     if (userName && userEmail) {
       return userName+' <'+userEmail+'>';


### PR DESCRIPTION
This was reported in https://github.com/github/generator-hubot/issues/15 . For some reason, `this.user.git.name` and `this.user.git.email` in this case weren't functions.

This is a workaround to check their type before calling them. If they aren't functions, they are assumed to be the value.

