### PR TITLE
Use hubot's name in shell adapter

### DIFF
--- a/generators/app/templates/Procfile
+++ b/generators/app/templates/Procfile
@@ -1,1 +1,1 @@
-web: bin/hubot -a <%= botAdapter %> -n <%= botName %>
+web: bin/hubot -a <%= botAdapter %>

--- a/generators/app/templates/bin/hubot
+++ b/generators/app/templates/bin/hubot
@@ -5,4 +5,4 @@ set -e
 npm install
 export PATH="node_modules/.bin:node_modules/hubot/node_modules/.bin:$PATH"
 
-exec node_modules/.bin/hubot "$@"
+exec node_modules/.bin/hubot --name "<%= botName %>" "$@"

--- a/generators/app/templates/bin/hubot.cmd
+++ b/generators/app/templates/bin/hubot.cmd
@@ -1,3 +1,3 @@
 @echo off
 
-npm install && node_modules\.bin\hubot.cmd %* 
+npm install && node_modules\.bin\hubot.cmd --name "<%= botName %>" %* 


### PR DESCRIPTION
It feels weird to name the bot during setup and then have it called `Hubot` regardless in local testing. So lets not do that anymore :smile_cat: 