### PR TITLE
Update script generator to work OOTB

### DIFF
--- a/generators/script/templates/.travis.yml
+++ b/generators/script/templates/.travis.yml
@@ -1,6 +1,11 @@
 language: node_js
 node_js:
-  - "0.11"
+  - "0.12"
   - "0.10"
+  - "iojs"
+sudo: false
+cache:
+  directories:
+    - node_modules
 notifications:
   email: false

--- a/generators/script/templates/Gruntfile.js
+++ b/generators/script/templates/Gruntfile.js
@@ -1,9 +1,6 @@
 'use strict';
 
-module.exports = function(grunt) {
-
-  grunt.loadNpmTasks('grunt-mocha-test');
-  grunt.loadNpmTasks('grunt-release');
+module.exports = function (grunt) {
 
   grunt.initConfig({
     mochaTest: {
@@ -22,17 +19,13 @@ module.exports = function(grunt) {
       }
     },
     watch: {
-      files: ['Gruntfile.js', 'test/**/*.coffee'],
+      files: ['Gruntfile.js', 'src/**/*.coffee', 'test/**/*.coffee'],
       tasks: ['test']
     }
   });
 
-  grunt.event.on('watch', function(action, filepath, target) {
-    grunt.log.writeln(target + ': ' + filepath + ' has ' + action);
-  });
-
   // load all grunt tasks
-  require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+  require('matchdep').filterDev(['grunt-*', '!grunt-cli']).forEach(grunt.loadNpmTasks);
 
   grunt.registerTask('test', ['mochaTest']);
   grunt.registerTask('test:watch', ['watch']);

--- a/generators/script/templates/_package.json
+++ b/generators/script/templates/_package.json
@@ -24,14 +24,18 @@
   },
 
   "devDependencies": {
+    "chai": "^2.1.1",
+    "coffee-script": "1.6.3",
+    "grunt": "^0.4.5",
+    "grunt-cli": "^0.1.13",
+    "grunt-contrib-watch": "~0.6.1",
+    "grunt-mocha-test": "~0.12.7",
+    "grunt-release": "~0.11.0",
     "hubot": "2.x",
-    "mocha": "*",
-    "coffee-script": "^1.6.3",
-    "sinon-chai": "*",
-    "grunt-mocha-test": "~0.7.0",
-    "grunt-release": "~0.6.0",
-    "matchdep": "~0.1.2",
-    "grunt-contrib-watch": "~0.5.3"
+    "matchdep": "~0.3.0",
+    "mocha": "^2.1.0",
+    "sinon": "^1.13.0",
+    "sinon-chai": "^2.7.0"
   },
 
   "main": "index.coffee",

--- a/generators/script/templates/gitignore
+++ b/generators/script/templates/gitignore
@@ -1,1 +1,1 @@
-node_modules
+/node_modules


### PR DESCRIPTION
  - Update dependencies
    - Add missing grunt and grunt-cli packages
    - Re-add chai and sinon to be npm 3.x compliant
    - Lock coffee-script to the same as hubot
  - Update travis config
    - Use new container architecture
    - Cache node_modules (faster test runs)
    - Switch from node 0.11 to 0.12 for testing
    - Add iojs to test matrix
  - Update Gruntfile
    - Add src directory to watch list
    - Load additional grunt tasks in consistent manor
    - Remove superfluous watch log message