### PR TITLE
We're only running Hubot, so skip dev packages

### DIFF
--- a/generators/app/templates/bin/hubot
+++ b/generators/app/templates/bin/hubot
@@ -2,7 +2,7 @@
 
 set -e
 
-npm install
+npm install --production
 export PATH="node_modules/.bin:node_modules/hubot/node_modules/.bin:$PATH"
 
 exec node_modules/.bin/hubot --name "<%= botName %>" "$@"


### PR DESCRIPTION
Shouldn't need `devDependencies` for this. Should make startup faster as there'll be a lot less packages to version check.