### PR TITLE
Release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+0.3.0
+=====
+
+* [app] update example.coffee to use `res` instead of `msg` https://github.com/github/generator-hubot/pull/36
+* [script] update generator to work better out of the box
+  - Update dependencies
+    - Add missing grunt and grunt-cli packages
+    - Re-add chai and sinon to be npm 3.x compliant
+    - Lock coffee-script to the same as hubot
+  - Update travis config
+    - Use new container architecture
+    - Cache node_modules (faster test runs)
+    - Switch from node 0.11 to 0.12 for testing
+    - Add iojs to test matrix
+  - Update Gruntfile
+    - Add src directory to watch list
+    - Load additional grunt tasks in consistent manor
+    - Remove superfluous watch log message
+
 0.2.1
 =====
 

--- a/generators/app/templates/scripts/example.coffee
+++ b/generators/app/templates/scripts/example.coffee
@@ -103,4 +103,4 @@ module.exports = (robot) ->
   #
   # robot.respond /sleep it off/i, (res) ->
   #   robot.brain.set 'totalSodas', 0
-  #   robot.respond 'zzzzz'
+  #   res.reply 'zzzzz'


### PR DESCRIPTION
* [app] update example.coffee to use `res` instead of `msg` - cc @geoffreyanderson  https://github.com/github/generator-hubot/pull/36
* [script] update generator to work better out of the box cc @mal https://github.com/github/generator-hubot/pull/34
  - Update dependencies
    - Add missing grunt and grunt-cli packages
    - Re-add chai and sinon to be npm 3.x compliant
    - Lock coffee-script to the same as hubot
  - Update travis config
    - Use new container architecture
    - Cache node_modules (faster test runs)
    - Switch from node 0.11 to 0.12 for testing
    - Add iojs to test matrix
  - Update Gruntfile
    - Add src directory to watch list
    - Load additional grunt tasks in consistent manor
    - Remove superfluous watch log message