### PR TITLE
Update grammar in generators/app/index.js

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -225,7 +225,7 @@ var HubotGenerator = yeoman.generators.Base.extend({
             npmName(name, function (err, available) {
               console.log("got back " + available);
               if (available) {
-                done("Can't that adapter on NPM, try again?");
+                done("Can't find that adapter on NPM, try again?");
                 return;
               }
 


### PR DESCRIPTION
Context: user puts in an adapter that doesn't exist.

Current:
```
? Description: A simple helpful robot for your Company
? Bot adapter: (campfire) Gitter
? Bot adapter: (campfire)
>> Can't that adapter on NPM, try again?
```

Small grammar change. 