### PR TITLE
Set path to sync hubot.cmd with hubot bash script

### DIFF
--- a/generators/app/templates/bin/hubot.cmd
+++ b/generators/app/templates/bin/hubot.cmd
@@ -1,3 +1,7 @@
 @echo off
 
+call npm install
+SETLOCAL
+SET PATH=node_modules\.bin;node_modules\hubot\node_modules\.bin;%PATH%
+
 npm install && node_modules\.bin\hubot.cmd --name "<%= botName %>" %* 

--- a/generators/app/templates/bin/hubot.cmd
+++ b/generators/app/templates/bin/hubot.cmd
@@ -4,4 +4,4 @@ call npm install
 SETLOCAL
 SET PATH=node_modules\.bin;node_modules\hubot\node_modules\.bin;%PATH%
 
-npm install && node_modules\.bin\hubot.cmd --name "<%= botName %>" %* 
+node_modules\.bin\hubot.cmd --name "<%= botName %>" %* 


### PR DESCRIPTION
This fixes issues with coffee-script not being installed globally and potentially other binary conflicts.