### PR TITLE
`xargs -i` was removed

### DIFF
--- a/generators/app/templates/README.md
+++ b/generators/app/templates/README.md
@@ -46,7 +46,7 @@ intensive. The following shell command can be used as a stop gap until an
 easier way to do this has been implemented.
 
     grep -o 'hubot-[a-z0-9_-]\+' external-scripts.json | \
-      xargs -n1 -i sh -c 'sed -n "/^# Configuration/,/^#$/ s/^/{} /p" \
+      xargs -n1 -I {} sh -c 'sed -n "/^# Configuration/,/^#$/ s/^/{} /p" \
           $(find node_modules/{}/ -name "*.coffee")' | \
         awk -F '#' '{ printf "%-25s %s\n", $1, $2 }'
 


### PR DESCRIPTION
```
$ xargs -i
xargs: illegal option -- i
```

According to [this](http://stackoverflow.com/questions/5192564/sutble-difference-in-using-xargs-and-xargs-i):

> Also, `-i` for `xargs` was deprecated around version 4.2.9. You should use `-I {}`.
