### PR TITLE
Fix link to hubot's README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A [Yeoman](http://yeoman.io) generator for creating your own chatbot using the H
 ## Getting Started
 
 See [Hubot's Getting Started
-guide](https://github.com/github/hubot/blob/master/docs/README.md) for
+guide](https://github.com/github/hubot/blob/master/docs/index.md) for
 details on getting up and running with your very own robot friend.
 `generator-hubot` is a replacement for `hubot --create`,
 so you skip that step if you've done `yo hubot` already.


### PR DESCRIPTION
It was renamed to index.md in https://github.com/github/hubot/pull/882