### PR TITLE
Remove hubot-youtube, since it requires an API key now

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -143,8 +143,7 @@ var HubotGenerator = yeoman.generators.Base.extend({
       'hubot-maps',
       'hubot-redis-brain',
       'hubot-rules',
-      'hubot-shipit',
-      'hubot-youtube'
+      'hubot-shipit'
     ];
 
     this.hubotScripts = [


### PR DESCRIPTION
This came up in https://github.com/hubot-scripts/hubot-youtube/pull/4 and https://github.com/hubot-scripts/hubot-youtube/issues/3 . It's currently broken, and once updated to the new API would require manual configuration.

We want the out of box hubot experience to work without much configuration, and this would be an extra step.

cc @stephenyeargin  