### PR TITLE
One-word change to link to Windows instructions correctly in README template

### DIFF
--- a/generators/app/templates/README.md
+++ b/generators/app/templates/README.md
@@ -181,7 +181,7 @@ hubot onto Windows][deploy-windows] wiki pages.
 [heroku-node-docs]: http://devcenter.heroku.com/articles/node-js
 [deploy-heroku]: https://github.com/github/hubot/blob/master/docs/deploying/heroku.md
 [deploy-unix]: https://github.com/github/hubot/blob/master/docs/deploying/unix.md
-[deploy-windows]: https://github.com/github/hubot/blob/master/docs/deploying/unix.md
+[deploy-windows]: https://github.com/github/hubot/blob/master/docs/deploying/windows.md
 
 ## Campfire Variables
 


### PR DESCRIPTION
Fixes #46. Just that simple.