### PR TITLE
miss (res) ?

### DIFF
--- a/generators/script/templates/src/template.coffee
+++ b/generators/script/templates/src/template.coffee
@@ -18,5 +18,5 @@ module.exports = (robot) ->
   robot.respond /hello/, (res) ->
     res.reply "hello!"
 
-  robot.hear /orly/, ->
+  robot.hear /orly/, (res) ->
     res.send "yarly"


### PR DESCRIPTION
I got this error:
hubot> [Thu Aug 20 2015 10:49:13 GMT+0800 (CST)] ERROR ReferenceError: res is not defined
  at TextListener.callback (/Users/tyan/GITHUB/hubot-maid/src/maid.coffee:22:5, <js>:7:14)
  at executeListener (/Users/tyan/DEMO/myhubot/node_modules/hubot/src/listener.coffee:65:11, <js>:53:19)
  at allDone (/Users/tyan/DEMO/myhubot/node_modules/hubot/src/middleware.coffee:40:37, <js>:29:16)
  at /Users/tyan/DEMO/myhubot/node_modules/hubot/node_modules/async/lib/async.js:274:13
  at Object.async.eachSeries (/Users/tyan/DEMO/myhubot/node_modules/hubot/node_modules/async/lib/async.js:142:20)
  at Object.async.reduce (/Users/tyan/DEMO/myhubot/node_modules/hubot/node_modules/async/lib/async.js:268:15)
  at /Users/tyan/DEMO/myhubot/node_modules/hubot/src/middleware.coffee:45:7, <js>:32:22
  at process._tickCallback (node.js:355:11)

------------------------------------------------
so I added (res) param