### PR TITLE
remove broken yo peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,8 +38,5 @@
     "grunt-release": "~0.6.0",
     "matchdep": "~0.1.2",
     "mocha": "*"
-  },
-  "peerDependencies": {
-    "yo": ">=1.0.0"
   }
 }


### PR DESCRIPTION
This corrects the error 

```
UNMET PEER DEPENDENCY yo@>=1.0.0
npm WARN EPEERINVALID generator-hubot@0.3.1 requires a peer of yo@>=1.0.0 but none was installed.
``` 
when using npm 3.3.11 and node 4.2.1.