### PR TITLE
Fix #64 prompting error

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -216,7 +216,7 @@ var HubotGenerator = yeoman.generators.Base.extend({
             var done = this.async();
 
             if (botAdapter == 'campfire') {
-              done(true);
+              done(null, true);
               return
             }
 
@@ -228,7 +228,7 @@ var HubotGenerator = yeoman.generators.Base.extend({
                 return;
               }
 
-              done(true);
+              done(null, true);
             });
           }
         });


### PR DESCRIPTION
This can fix issues #64.

It seems that first argument of `done()` expects error object, and second one expects return value.