### PR TITLE
cleaned up checking of availability of adapter on npm

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -221,8 +221,8 @@ var HubotGenerator = yeoman.generators.Base.extend({
             }
 
             var name = 'hubot-' + botAdapter;
-            npmName(name, function (err, available) {
-              if (available) {
+            npmName(name, function (err, unavailable) {
+              if (unavailable) {
                 done("Can't find that adapter on NPM, try again?");
                 return;
               }

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -222,7 +222,6 @@ var HubotGenerator = yeoman.generators.Base.extend({
 
             var name = 'hubot-' + botAdapter;
             npmName(name, function (err, available) {
-              console.log("got back " + available);
               if (available) {
                 done("Can't find that adapter on NPM, try again?");
                 return;


### PR DESCRIPTION
1. Removed what seemed like an extraneous console.log statement.
2. Changed variable name from 'available' to 'unavailable', to match both the npm-name api, and what the generator-hubot code is actually doing. Only the name of the variable was off, and was causing confusion.